### PR TITLE
docs: document TRACK usage and add smoke-check

### DIFF
--- a/.github/workflows/check-track.yml
+++ b/.github/workflows/check-track.yml
@@ -1,0 +1,46 @@
+name: Check TRACK smoke
+
+on:
+  pull_request:
+    paths:
+      - 'TRACK'
+      - 'api-factory/**'
+      - 'apps/api-cli/**'
+      - 'scripts/check-track.sh'
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build api image
+        run: |
+          docker build -f Dockerfile.api -t api-factory-track:latest .
+
+      - name: Run api container
+        run: |
+          docker run -d --name api-factory-track -p 8787:8787 api-factory-track:latest
+
+      - name: Wait for api
+        run: |
+          for i in {1..20}; do
+            if curl -sfS http://127.0.0.1:8787/_meta >/dev/null 2>&1; then
+              echo "api up"; break
+            fi
+            sleep 1
+          done
+
+      - name: Run smoke check script
+        run: |
+          chmod +x ./scripts/check-track.sh
+          ./scripts/check-track.sh http://127.0.0.1:8787/_meta
+
+      - name: Teardown
+        if: always()
+        run: |
+          docker rm -f api-factory-track || true

--- a/README.md
+++ b/README.md
@@ -854,6 +854,14 @@ config: {
   }
 }
 
+## TRACK file
+
+This repository contains a top-level `TRACK` file (for example: `MVP`) that records the active release track.
+
+- Workflows load `TRACK` into `env.TRACK` so CI can conditionally change behavior.
+- Services read `process.env.TRACK` at runtime or fall back to the `TRACK` file.
+- You can check the active track by calling the API `_meta` endpoint (e.g. `GET http://localhost:8787/_meta`).
+
 // OpenAPI Specification
 openapi: 3.0.3
 info:

--- a/docs/TRACK.md
+++ b/docs/TRACK.md
@@ -1,0 +1,14 @@
+# Repository TRACK
+
+This repository includes a top-level `TRACK` file that records the active release track.
+
+Purpose
+- Provide a single source of truth for the release track (for example: `MVP`, `canary`, `stable`).
+
+How it's used
+- GitHub Actions: workflows load `TRACK` into the job environment as `TRACK`.
+- Runtime: services read `process.env.TRACK` or fall back to the `TRACK` file.
+- Docker: Dockerfiles accept `ARG TRACK` and set `ENV TRACK` so containers see the value.
+
+Quick check
+- Start the `api-cli` service (locally or in Docker) and call `GET /_meta` to see the active track.

--- a/scripts/check-track.sh
+++ b/scripts/check-track.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple smoke test: call the api-cli _meta endpoint and print the track
+URL=${1:-http://127.0.0.1:8787/_meta}
+echo "Checking TRACK at $URL"
+resp=$(curl -sSfL "$URL" || true)
+if [ -z "$resp" ]; then
+  echo "no response from $URL" >&2
+  exit 2
+fi
+echo "response: $resp"
+if echo "$resp" | grep -iq 'track'; then
+  echo "TRACK found"
+  exit 0
+else
+  echo "TRACK not present in response" >&2
+  exit 3
+fi


### PR DESCRIPTION
Add  explaining the TRACK file and a small smoke script  to validate the /_meta endpoint.